### PR TITLE
Integer overflow leading to incorrect computation of sha3 (#1312)

### DIFF
--- a/src/common/sha3/xkcp_sha3.c
+++ b/src/common/sha3/xkcp_sha3.c
@@ -104,10 +104,9 @@ static void keccak_inc_reset(uint64_t *s) {
  **************************************************/
 static void keccak_inc_absorb(uint64_t *s, uint32_t r, const uint8_t *m,
                               size_t mlen) {
-	uint64_t c;
+	uint64_t c = r - s[25];
 
-	if (s[25] && mlen + s[25] >= r) {
-		c = r - s[25];
+	if (s[25] && mlen >= c) {
 		(*Keccak_AddBytes_ptr)(s, m, (unsigned int)s[25], (unsigned int)c);
 		(*Keccak_Permute_ptr)(s);
 		mlen -= c;

--- a/src/common/sha3/xkcp_sha3x4.c
+++ b/src/common/sha3/xkcp_sha3x4.c
@@ -70,10 +70,9 @@ static void keccak_x4_inc_reset(uint64_t *s) {
 
 static void keccak_x4_inc_absorb(uint64_t *s, uint32_t r,
                                  const uint8_t *in0, const uint8_t *in1, const uint8_t *in2, const uint8_t *in3, size_t inlen) {
-	uint64_t c;
+	uint64_t c = r - s[100];
 
-	if (s[100] && inlen + s[100] >= r) {
-		c = r - s[100];
+	if (s[100] && inlen >= c) {
 		(*Keccak_X4_AddBytes_ptr)(s, 0, in0, (unsigned int)s[100], (unsigned int)c);
 		(*Keccak_X4_AddBytes_ptr)(s, 1, in1, (unsigned int)s[100], (unsigned int)c);
 		(*Keccak_X4_AddBytes_ptr)(s, 2, in2, (unsigned int)s[100], (unsigned int)c);


### PR DESCRIPTION
Suppose a user of the incremental SHA3 API absorbs 10 bytes, and then absorbs 2^64 - 10 bytes. At the beginning of the second `keccak_inc_absorb` call, the 25th element of the Keccak state is equal to 10, and there is a uint64_t overflow in
```
if (s[25] && mlen + s[25] >= r)
```
which causes the branch to be skipped. Later code assumes that mlen >= r implies that s[25] = 0, and calls
```
(*Keccak_AddBytes_ptr)(s, m, 0, r);
```
with third argument 0 instead of s[25]. This call modifies the wrong elements of the Keccak state, which leads to an incorrect result.

I went looking for bugs of this form because of CVE-2022-37454, but this one is not a security concern. It is also largely theoretical since it involves processing close to 2^64 bytes.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
